### PR TITLE
Fix issue: JS not loading from browser cache when page builder render

### DIFF
--- a/app/code/Magento/PageBuilder/view/adminhtml/web/template/page-builder.html
+++ b/app/code/Magento/PageBuilder/view/adminhtml/web/template/page-builder.html
@@ -31,6 +31,6 @@
         <with args="stage">
             <render></render>
         </with>
-        <iframe attr="id: 'render_frame_' + id" sandbox="allow-scripts" style="position: absolute; width:0; height:0; border: none;"></iframe>
+        <iframe attr="id: 'render_frame_' + id" sandbox="allow-scripts allow-same-origin" style="position: absolute; width:0; height:0; border: none;"></iframe>
     </if>
 </div>


### PR DESCRIPTION
Issue: https://github.com/magento/magento2/issues/37798

**Preconditions and environment**
Magento version: 2.4.5-p2 and 2.4.6
PageBuilder is enabled
Chrome 112 and newer
CMS page with pagebuilder content
**Steps to reproduce**
Use Chrome version 112 or above
Edit CMS Page, Product or anything that has PageBuilder.
Save page. It takes very long time or save or loading forever.
JS file is loading from the networks instead of browser cache, so that saving is very slow
**Expected result**
The content saving quickly.
JS file should getting from browser cache

**Actual result**
JS files always loading from the networks.
The content saving very slow. Sometime its stuck forever.

**Additional information**
I see that the issue happen when page builder rendering in iframe. Some js file is always loading from networks instead of browser cached. So that we have to spent more time to wait until all js file is loading correct.
Sometime, when network is slow. The spin loading forever and the content is not save and we will lost the current work.